### PR TITLE
Update issue templates with detailed tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/🐛-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/🐛-bug-report.md
@@ -1,8 +1,8 @@
 ---
 name: "\U0001F41B Bug Report"
 about: 버그를 리포트할 때 사용하는 템플릿
-title: "[BUG] "
-labels: bug
+title: "[FE/BUG] "
+labels: bug, Discussion, major, minor, Non-code work, On-code work, urgent
 assignees: soonhong99
 
 ---

--- a/.github/ISSUE_TEMPLATE/💡-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/💡-feature-request.md
@@ -1,8 +1,8 @@
 ---
 name: "\U0001F4A1 Feature Request"
 about: 새로운 기능을 제안할 때 사용하는 템플릿
-title: "[FEATURE]"
-labels: enhancement
+title: "[FE/FEATURE]"
+labels: Discussion, enhancement, major, minor, Non-code work, On-code work, urgent
 assignees: soonhong99
 
 ---

--- a/.github/ISSUE_TEMPLATE/📚-documentation.md
+++ b/.github/ISSUE_TEMPLATE/📚-documentation.md
@@ -1,8 +1,8 @@
 ---
 name: "\U0001F4DA Documentation"
 about: 문서 업데이트를 제안할 때 사용하는 템플릿
-title: "[DOC] "
-labels: documentation
+title: "[FE/DOC] "
+labels: Discussion, documentation, major, minor, Non-code work, On-code work, urgent
 assignees: soonhong99
 
 ---


### PR DESCRIPTION
- 우선순위 및 코드가 필요한 일인지, 논의가 필요한 일인지 더 구체적인 태그를 이용하여 세분화 

- 제목을 지을 때 앞에 FE 인지, BE인지 파악할 수 있도록 default title 수정
