### PR TITLE
[BE:Feat] MSA 기반의 프로젝트를 위한 각 모듈별 기본 설정 및 패키지 구조 구성

### DIFF
--- a/api-gateway/src/main/java/com/metalog/api_gateway/config/RouteConfig.java
+++ b/api-gateway/src/main/java/com/metalog/api_gateway/config/RouteConfig.java
@@ -1,0 +1,4 @@
+package com.metalog.api_gateway.config;
+
+public class RouteConfig {
+}

--- a/api-gateway/src/main/java/com/metalog/api_gateway/filter/AuthFilter.java
+++ b/api-gateway/src/main/java/com/metalog/api_gateway/filter/AuthFilter.java
@@ -1,0 +1,4 @@
+package com.metalog.api_gateway.filter;
+
+public class AuthFilter {
+}

--- a/api-gateway/src/main/java/com/metalog/api_gateway/filter/CorsFilter.java
+++ b/api-gateway/src/main/java/com/metalog/api_gateway/filter/CorsFilter.java
@@ -1,0 +1,4 @@
+package com.metalog.api_gateway.filter;
+
+public class CorsFilter {
+}

--- a/api-gateway/src/main/java/com/metalog/api_gateway/filter/LoggingFilter.java
+++ b/api-gateway/src/main/java/com/metalog/api_gateway/filter/LoggingFilter.java
@@ -1,0 +1,4 @@
+package com.metalog.api_gateway.filter;
+
+public class LoggingFilter {
+}

--- a/api-gateway/src/main/resources/application.properties
+++ b/api-gateway/src/main/resources/application.properties
@@ -1,1 +1,6 @@
+server.port=8000
+
 spring.application.name=api-gateway
+spring.cloud.gateway.discovery.locator.enabled=true
+
+eureka.client.service-url.defaultZone=http://localhost:8761/eureka/

--- a/config-server/src/main/resources/application.properties
+++ b/config-server/src/main/resources/application.properties
@@ -1,1 +1,4 @@
+server.port=8888
+
 spring.application.name=config-server
+spring.cloud.config.server.git.uri={https://github.com/soonhong99/metalog-configs}

--- a/config-server/src/main/resources/application.properties
+++ b/config-server/src/main/resources/application.properties
@@ -2,3 +2,5 @@ server.port=8888
 
 spring.application.name=config-server
 spring.cloud.config.server.git.uri={https://github.com/soonhong99/metalog-configs}
+
+eureka.client.service-url.defaultZone=http://localhost:8761/eureka/

--- a/eureka-server/src/main/resources/application.properties
+++ b/eureka-server/src/main/resources/application.properties
@@ -1,1 +1,6 @@
+server.port=8761
+
 spring.application.name=eureka-server
+
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -1,1 +1,5 @@
+server.port=8100
+
 spring.application.name=user-service
+
+eureka.client.service-url.defaultZone=http://localhost:8761/eureka/


### PR DESCRIPTION
## 🔍 변경 사항
### 1. Application Properties 설정
#### API Gateway (Port: 8000)
포트번호 8000으로 설정한 이유
- 외부 요청이 처음 진입하는 지점이므로 기억하기 쉬운 포트번호 사용

eureka 서버의 client로 등록

---

#### Eureka Server (Port: 8761)
포트번호 8761로 설정한 이유
- Eureka Server의 기본 포트 번호 (관례적으로 8761 사용)

자기 자신을 eureka 서버에 등록하지 않도록 하였으며
레지스트리 정보를 로컬에 캐싱하지 않도록 함.

---

#### Config Server (Port:8888)
포트번호 8888로 설정한 이유
- Config Server의 기본 포트 번호 (관례적으로 8888 사용)

설정 파일들을 저장할 git 저장소 주소를 입력하여 중앙 집중식 설정 관리를 할 수 있게 함.

eureka 서버의 client로 등록

---

#### User service (Port:8100)
포트번호 8100으로 설정한 이유
- MSA에서는 각 서비스가 독립적인 포트를 사용해야 한다.
- 보통 8000번대를 사용하며, 비즈니스 서비스들은 8100번대부터 시작하기에 해당 포트번호로 설정

eureka 서버의 client로 등록

### 2. 패키지 구조 설정
#### API Gateway
```
com.metalog.apigateway/
├── config/
│   └── RouteConfig.java
├── filter/
│   ├── AuthFilter.java
│   └── LoggingFilter.java
└── ApiGatewayApplication.java
```

#### User Service
```
com.metalog.userservice/
├── config/
├── controller/
├── service/
├── repository/
├── model/
│   ├── entity/
│   └── dto/
├── exception/
└── UserServiceApplication.java
```

## ✅ 테스트 항목
- [ ] 각 모듈의 application.yml 설정이 정상적으로 로드되는지 확인
- [ ] API Gateway의 라우팅 설정이 정상 작동하는지 확인
- [ ] Eureka Server에 서비스들이 정상 등록되는지 확인
- [ ] 각 모듈의 기본 패키지 구조가 정상적으로 생성되었는지 확인

## 🤔 추가적으로 해야할 사항
#### Eureka Server
- 서비스 레지스트리 설정

---

#### User Service
- 데이터베이스 연결 설정
- Eureka Client 설정

---

#### API Gateway
- 서비스 라우팅 설정
- Eureka Client 설정
- CORS 설정

---

#### Config Server
- Git Repository 연동 설정
- 암호화 설정

## 🔄 관련 이슈
- Closes #6 